### PR TITLE
Install package.xml and register package in the ament index.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,10 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'launch_ros_sandbox'
+
 setup(
-    name='launch_ros_sandbox',
+    name=package_name,
     version='0.1.0',
     packages=find_packages(exclude=['test']),
     data_files=[

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,11 @@ setup(
     name='launch_ros_sandbox',
     version='0.1.0',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+    ],
     install_requires=[
         'setuptools',
         'launch',


### PR DESCRIPTION
*Description of changes:*

ament_python packages need to install data files explicitly which are managed
behind the scenes in ament_cmake packages.

This package had the data files (resource/launch_ros_sandbox and
package.xml) created already but didn't include the setup.py field to
install them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


I haven't built this locally, it's a bit of a drive-by while investigating other issues with the release of this package into Dashing.