### PR TITLE
Verify w/ unit tests that the proper flags are propagated

### DIFF
--- a/test/launch_ros_sandbox/descriptions/test_docker_policy.py
+++ b/test/launch_ros_sandbox/descriptions/test_docker_policy.py
@@ -131,3 +131,21 @@ class TestDockerPolicy(unittest.TestCase):
 
         assert docker_policy.repository == 'foo'
         assert docker_policy.entrypoint == '/bin/bash -c'
+
+    def test_run_args_set_correctly(self) -> None:
+        """Verify the DockerPolicy run arguments match for the Docker Image."""
+        run_args = {
+                'cpuset_cpus': 0,
+                'mem_limit': '128m'
+            }
+        docker_policy = DockerPolicy(
+            run_args=run_args
+        )
+
+        assert docker_policy.run_args == run_args
+
+    def test_empty_run_args_set_correctly(self) -> None:
+        """Verify the DockerPolicy has no run args if not set."""
+        docker_policy = DockerPolicy()
+
+        assert docker_policy.run_args is None


### PR DESCRIPTION
*Description of changes:*

2 Unit tests that make sure the `run_args` passed to `DockerPolicy` are correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.