### PR TITLE
E2E Testing for DockerPolicy run_args

### DIFF
--- a/examples/cpu_limit_sandbox_docker.launch.py
+++ b/examples/cpu_limit_sandbox_docker.launch.py
@@ -70,7 +70,7 @@ def generate_launch_description() -> LaunchDescription:
                 repository='osrf/ros',
                 container_name='sandboxed-listener-node',
                 run_args={
-                    'cpuset_cpus':'0'
+                    'cpuset_cpus': '0'
                 }
             ),
             node_descriptions=[

--- a/examples/mem_limit_sandbox_docker.launch.py
+++ b/examples/mem_limit_sandbox_docker.launch.py
@@ -67,7 +67,7 @@ def generate_launch_description() -> LaunchDescription:
                 repository='osrf/ros',
                 container_name='sandboxed-listener-node',
                 run_args={
-                    'mem_limit':'128m'
+                    'mem_limit': '128m'
                 }
             ),
             node_descriptions=[

--- a/test/launch_ros_sandbox/test_docker_policy_run_args.sh
+++ b/test/launch_ros_sandbox/test_docker_policy_run_args.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# pull the image now so that we don't have to guess/query when its done in the script
+docker pull osrf/ros:dashing-desktop
+
+# run the example; loads listener in Docker
+./examples/mem_limit_sandbox_docker.launch.py&
+task_id=$!
+
+echo "TaskID: $task_id"
+
+echo "Checking if sandboxed-listener-node is running..."
+docker inspect -f "{{.State.Running}}" sandboxed-listener-node
+is_running=$?
+
+# Wait until the docker container is running. docker inspect will return 0 when it does.
+while [[ $is_running -ne 0 ]]
+do
+  sleep 1
+  docker inspect -f "{{.State.Running}}" sandboxed-listener-node
+  is_running=$?
+done
+
+# Run listener in the container spun up by DockerPolicy for 5 seconds
+echo "Executing listener in Docker container..."
+# TODO: Execute command to check for memory size
+# timeout 5 docker exec -t sandboxed-listener-node /ros_entrypoint.sh ros2 run demo_nodes_cpp listener
+echo "Stopping Docker container..."
+
+# Note: these sleep commands are here just so the following command executes after stdout appears on
+# the terminal.
+kill -INT $task_id
+sleep 2
+
+# SIGTERM is required also if launch is ran in the background, this might be a bug in launch.
+kill $task_id
+sleep 2
+
+echo "Checking if sandboxed-listener-node is running..."
+docker inspect -f "{{.State.Running}}" sandboxed-listener-node
+
+# Check the exit code of docker inspect. 0 is returned only if it is running.
+# This check will set the exit code to 0 only if the exit code is not 0.
+[[ $? -ne 0 ]]
+
+exit $?

--- a/test/test_docker_policy.sh
+++ b/test/test_docker_policy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NORM='\033[0m'
+
 # pull the image now so that we don't have to guess/query when its done in the script
 docker pull osrf/ros:dashing-desktop
 
@@ -40,6 +44,10 @@ docker inspect -f "{{.State.Running}}" sandboxed-listener-node
 
 # Check the exit code of docker inspect. 0 is returned only if it is running.
 # This check will set the exit code to 0 only if the exit code is not 0.
-[[ $? -ne 0 ]]
-
-exit $?
+if [[ $? -ne 0 ]]; then
+  printf "${GREEN}PASS${NORM}\n"
+  exit 0
+else
+  printf "${RED}FAIL${NORM}\n"
+  exit 1
+fi

--- a/test/test_docker_policy_run_args.sh
+++ b/test/test_docker_policy_run_args.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+
 # pull the image now so that we don't have to guess/query when its done in the script
 docker pull osrf/ros:dashing-desktop
 
@@ -22,9 +25,14 @@ do
 done
 
 # Run listener in the container spun up by DockerPolicy for 5 seconds
-echo "Executing listener in Docker container..."
-# TODO: Execute command to check for memory size
-# timeout 5 docker exec -t sandboxed-listener-node /ros_entrypoint.sh ros2 run demo_nodes_cpp listener
+echo "Checking memory limits in Docker container..."
+memory=$(docker inspect sandboxed-listener-node | jq '.[0].HostConfig.Memory')
+if [[ "$memory" -eq "134217728" ]]; then
+    printf "${GREEN}Memory limits correctly set to 128m!\n";
+else
+    printf "${RED}Memory limits not correctly set to 128m!\n";
+fi
+
 echo "Stopping Docker container..."
 
 # Note: these sleep commands are here just so the following command executes after stdout appears on

--- a/test/test_docker_policy_run_args.sh
+++ b/test/test_docker_policy_run_args.sh
@@ -2,6 +2,7 @@
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+NORM='\033[0m'
 
 # pull the image now so that we don't have to guess/query when its done in the script
 docker pull osrf/ros:dashing-desktop
@@ -28,9 +29,9 @@ done
 echo "Checking memory limits in Docker container..."
 memory=$(docker inspect sandboxed-listener-node | jq '.[0].HostConfig.Memory')
 if [[ "$memory" -eq "134217728" ]]; then
-    printf "${GREEN}Memory limits correctly set to 128m!\n";
+    printf "${GREEN}Memory limits correctly set to 128m!${NORM}\n";
 else
-    printf "${RED}Memory limits not correctly set to 128m!\n";
+    printf "${RED}Memory limits not correctly set to 128m!${NORM}\n";
 fi
 
 echo "Stopping Docker container..."

--- a/test/test_docker_policy_run_args.sh
+++ b/test/test_docker_policy_run_args.sh
@@ -29,9 +29,11 @@ done
 echo "Checking memory limits in Docker container..."
 memory=$(docker inspect sandboxed-listener-node | jq '.[0].HostConfig.Memory')
 if [[ "$memory" -eq "134217728" ]]; then
-    printf "${GREEN}Memory limits correctly set to 128m!${NORM}\n";
+    printf "${GREEN}PASS: Memory limits correctly set to 128m!${NORM}\n";
+    result=0
 else
-    printf "${RED}Memory limits not correctly set to 128m!${NORM}\n";
+    printf "${RED}FAIL: Memory limits not correctly set to 128m!${NORM}\n";
+    result=1
 fi
 
 echo "Stopping Docker container..."
@@ -49,7 +51,7 @@ echo "Checking if sandboxed-listener-node is running..."
 docker inspect -f "{{.State.Running}}" sandboxed-listener-node
 
 # Check the exit code of docker inspect. 0 is returned only if it is running.
-# This check will set the exit code to 0 only if the exit code is not 0.
-[[ $? -ne 0 ]]
+# This check will set the exit code to 0 only if the Docker container is not running and the memory check passed.
+[[ $? -ne 0 && result -eq 0 ]]
 
 exit $?


### PR DESCRIPTION
*Description of changes:*

An E2E test for making sure that the memory limit (and in turn the run_args) specified in the `mem_limit_sandbox_docker.launch` file works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
