### PR TITLE
Add logging of nodes ran in Docker containers

### DIFF
--- a/examples/talker_listener_sandbox_docker.launch.py
+++ b/examples/talker_listener_sandbox_docker.launch.py
@@ -52,11 +52,10 @@ def generate_launch_description() -> LaunchDescription:
     """
     Create launch description for starting SandboxedNodeContainer with DockerPolicy.
 
-    Talker is loaded inside the SandboxedNodeContainer.
+    Talker and Listener are both loaded inside the SandboxedNodeContainer.
     When the sandboxed node is executed, it runs the ROS 2 node within the Docker container.
     The container continues to run until stopped externally.
-    The talker node can be interacted with by launching a listener node.
-    The listener node does not need to be launched from within the Docker container.
+    The output of the talker and listener nodes should be logged to the host machine's stdout.
     """
     ld = LaunchDescription()
 

--- a/examples/talker_listener_sandbox_docker.launch.py
+++ b/examples/talker_listener_sandbox_docker.launch.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Minimal example for using SandboxedNodeContainer with DockerPolicy.
+
+This example runs a ROS 2 node in a sandboxed environment by invoking SandboxedNodeContainer
+action. SandboxedNodeContainer delegates the launch parameters to an instance of launch_ros that is
+running in a Docker container.
+
+Currently, this test will only launch the Talker demo node inside Docker. This node can be observed
+by launching a Listener node either within the same docker container or on the host machine. The
+Docker container must be stopped externally in order to free resources.
+
+"container_id" should be substituted for the container name logged by launch. It can also be found
+by running "docker container ls".
+
+How to stop the Docker container:
+- docker stop $container_id
+
+How to run listener inside the Docker container
+- docker exec -it $container_id /bin/bash
+- source /ros_entrypoint.sh
+- ros2 run demo_nodes_cpp listener
+"""
+
+import sys
+
+from launch import LaunchDescription
+from launch import LaunchService
+
+from launch_ros_sandbox.actions import SandboxedNodeContainer
+from launch_ros_sandbox.descriptions import DockerPolicy
+from launch_ros_sandbox.descriptions import SandboxedNode
+
+
+def generate_launch_description() -> LaunchDescription:
+    """
+    Create launch description for starting SandboxedNodeContainer with DockerPolicy.
+
+    Talker is loaded inside the SandboxedNodeContainer.
+    When the sandboxed node is executed, it runs the ROS 2 node within the Docker container.
+    The container continues to run until stopped externally.
+    The talker node can be interacted with by launching a listener node.
+    The listener node does not need to be launched from within the Docker container.
+    """
+    ld = LaunchDescription()
+
+    ld.add_action(
+        SandboxedNodeContainer(
+            sandbox_name='my_sandbox',
+            policy=DockerPolicy(
+                tag='dashing-desktop',
+                repository='osrf/ros',
+                container_name='sandboxed-listener-node',
+            ),
+            node_descriptions=[
+                SandboxedNode(
+                    package='demo_nodes_cpp',
+                    node_executable='talker',
+                ),
+                SandboxedNode(
+                    package='demo_nodes_cpp',
+                    node_executable='listener'
+                )
+            ]
+        )
+    )
+
+    return ld
+
+
+if __name__ == '__main__':
+    """Starts the SandboxedNodeContainer example as a script."""
+
+    ls = LaunchService(argv=sys.argv[1:], debug=True)
+    ls.include_launch_description(generate_launch_description())
+    sys.exit(ls.run())

--- a/launch_ros_sandbox/actions/load_docker_nodes.py
+++ b/launch_ros_sandbox/actions/load_docker_nodes.py
@@ -163,6 +163,13 @@ class LoadDockerNodes(Action):
         self,
         log_generator
     ) -> None:
+        """
+        Process the logs from a container and print to the logger.
+
+        Expects the `log generator` returned from Docker-py's container.exec_run.
+        The generator blocks until a new log chunk is available.
+        The log chunk is of type `bytes`, so it must be decoded before its sent to the logger.
+        """
         for log in log_generator:
             self.__logger.info(log.decode('utf-8').rstrip())
 

--- a/launch_ros_sandbox/actions/load_docker_nodes.py
+++ b/launch_ros_sandbox/actions/load_docker_nodes.py
@@ -147,14 +147,23 @@ class LoadDockerNodes(Action):
                 executable=executable_name
             )
 
-            self._container.exec_run(
+            log_generator = self._container.exec_run(
                 cmd=cmd,
-                detach=True,
                 tty=True,
+                stream=True,
             )
+
+            context.asyncio_loop.create_task(self._handle_logs(log_generator))        
 
             self.__logger.debug('Running \"{}\" in container: \"{}\"'
                                 .format(cmd, self._policy.container_name))
+
+    async def _handle_logs(
+        self,
+        log_generator
+    ) -> None:
+        for log in log_generator:
+            print(log.decode('utf-8'))
 
     async def _start_docker_nodes(
         self,
@@ -191,7 +200,7 @@ class LoadDockerNodes(Action):
             OnShutdown(
                 on_shutdown=self.__on_shutdown
             )
-        )
+        )    
 
         self._completed_future = create_future(context.asyncio_loop)
 

--- a/launch_ros_sandbox/actions/load_docker_nodes.py
+++ b/launch_ros_sandbox/actions/load_docker_nodes.py
@@ -201,7 +201,7 @@ class LoadDockerNodes(Action):
             OnShutdown(
                 on_shutdown=self.__on_shutdown
             )
-        )    
+        )
 
         self._completed_future = create_future(context.asyncio_loop)
 
@@ -240,3 +240,5 @@ class LoadDockerNodes(Action):
                 if self._container is not None:
                     self._container.stop()
                     self._container = None
+
+        return None


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Add log streaming of nodes ran in Docker containers
* Add `examples/talker_listener_sandboxed_docker.launch.py` for testing logging.

*Manual QA*
1. install `launch_ros_sandbox`
2. run `examples/talker_listener_sandboxed_docker.launch.py`
3. Verify that `Listener` hears `Talker` in the terminal
4. `ctrl+c` and verify container is brought down.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
