### PR TITLE
More robust checking in loghandler

### DIFF
--- a/launch_ros_sandbox/actions/load_docker_nodes.py
+++ b/launch_ros_sandbox/actions/load_docker_nodes.py
@@ -23,6 +23,7 @@ as a Docker container. This Action is not exported and should only be used inter
 from asyncio import CancelledError, Future
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
+from types import GeneratorType
 from typing import List, Optional
 
 import docker
@@ -161,7 +162,7 @@ class LoadDockerNodes(Action):
 
     def _handle_logs(
         self,
-        log_generator
+        log_generator: GeneratorType
     ) -> None:
         """
         Process the logs from a container and print to the logger.
@@ -171,7 +172,16 @@ class LoadDockerNodes(Action):
         The log chunk is of type `bytes`, so it must be decoded before its sent to the logger.
         """
         for log in log_generator:
-            self.__logger.info(log.decode('utf-8').rstrip())
+            if not log:
+                pass  # Sometimes we receive None
+            elif isinstance(log, GeneratorType):
+                for l in log:
+                    self.__logger.info(l.decode('utf-8').strip())
+            else:
+                try:
+                    self.__logger.info(log.decode('utf-8').strip())
+                except (UnicodeDecodeError, AttributeError):
+                    self.__logger.error('Unable to print log of type {}'.format(type(log)))
 
     async def _start_docker_nodes(
         self,

--- a/launch_ros_sandbox/actions/load_docker_nodes.py
+++ b/launch_ros_sandbox/actions/load_docker_nodes.py
@@ -181,7 +181,7 @@ class LoadDockerNodes(Action):
                 try:
                     self.__logger.info(log.decode('utf-8').strip())
                 except (UnicodeDecodeError, AttributeError):
-                    self.__logger.error('Unable to print log of type {}'.format(type(log)))
+                    self.__logger.exception('Unable to print log of type {}'.format(type(log)))
 
     async def _start_docker_nodes(
         self,


### PR DESCRIPTION

*Description of changes:*

The logging didn't work for me out of the box, it just choked on log types that were generators within the generator. Just ran 

```
ros2 launch launch_ros_sandbox/examples/talker_listener_sandbox_docker.launch.py
```

Using dashing patch release 2.

Added some checkers for more robustness in this callback handler