### PR TITLE
Fix readthedocs documentation generation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,14 +1,16 @@
 version: 2
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 python:
   version: 3.6
-  # system_packages: true
   install:
     # Install requirements as system packages using pip
     - requirements: docs/requirements.txt
+    # Ensure sphinx-build is in PATH
+    - method: setuptools
+      path: docs/sphinx_build_symlink/
     # Install launch-ros-sandbox using setuptools
     - method: setuptools
       path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,5 @@
-Sphinx==2.2.0
-recommonmark==0.6.0
+# Install ROS 2 dependencies using pip to help sphinx generate documentation API
+# This should *not* be used with the intent of actually running the software, colcon should
+# be used in this case.
+git+https://github.com/ament/ament_index.git#egg=ament_index_python&subdirectory=ament_index_python
+git+https://github.com/ros2/launch.git#egg=launch&subdirectory=launch

--- a/docs/sphinx_build_symlink/setup.py
+++ b/docs/sphinx_build_symlink/setup.py
@@ -1,0 +1,42 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Looks for sphinx-build in lib/ and creates a symlink in bin/.
+
+This workaround mitigates an issue in readthedocs with sphinx where the
+sphinx-build binary is installed in a directory which is not listed in PATH,
+causing the documentation generation to fail (failed to open sphinx-build).
+"""
+
+import os
+import pathlib
+
+from setuptools import setup
+
+
+sphinx_build = next(pathlib.Path('/').glob('**/sphinx-build'))
+
+# Looking for the venv bin directory. The home directory is
+# chosen as a starting point, because it excludes system bin
+# packages, and the venv is a subdirectory of the home dir.
+bin_directory = next(pathlib.Path.home().glob('**/bin'))
+os.symlink(sphinx_build, bin_directory / 'sphinx-build')
+
+package_name = 'sphinx_build_symlink'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+)


### PR DESCRIPTION
readthedocs makes the assumption that the binary sphinx-build
will be located in the venv binary directory.

readthedocs logs demonstrate that this binary is actually installed
in <venv root dir>/lib/launch_ros_sandbox.

While the reason for this behavior is unclear, this changes work
around this issue creating a symbolic link to sphinx-build in the
bin directory to ensure that sphinx-build will find the binary
as expected.

To do so, a fake Python package is introduced in
doc/sphinx_build_symbolink. This fake package is added to
.readthedocs.yml so that its setup.py is executed before
documentation generation. Using a fake package ensures that no
production code is touched by this workaround.

This commit also fixes the .readthedoc.yml file by:
 - fixing the path to conf.py which was incorrect
 - removing commented out configuration options

Fix #22

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
