### PR TITLE
Use HTTPS Git url in repos file

### DIFF
--- a/launch_ros_sandbox.dashing.repos
+++ b/launch_ros_sandbox.dashing.repos
@@ -1,5 +1,5 @@
 repositories:
   launch_ros_sandbox:
     type: git
-    url: git@github.com:aws-robotics/launch-ros-sandbox.git
+    url: https://github.com/aws-robotics/launch-ros-sandbox.git
     version: dashing-devel

--- a/launch_ros_sandbox.repos
+++ b/launch_ros_sandbox.repos
@@ -1,5 +1,5 @@
 repositories:
   launch_ros_sandbox:
     type: git
-    url: git@github.com:aws-robotics/launch-ros-sandbox.git
+    url: https://github.com/aws-robotics/launch-ros-sandbox.git
     version: master


### PR DESCRIPTION
Previously, the SSH clone URL was used which is preventing
cloning for users who do not have write access to the repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
