### PR TITLE
Add Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+addons:
+  apt:
+    sources:
+    - sourceline: 'deb http://packages.ros.org/ros2/ubuntu bionic main'
+      key_url: 'https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc'
+    packages:
+    - curl
+    - python-rosdep
+    - python3-colcon-common-extensions
+    - python3-vcstool
+    # Fast-RTPS dependencies
+    - libasio-dev
+    - libtinyxml2-dev
+    update: true
+before_script:
+- sudo rosdep init
+- rosdep update
+cache: apt
+dist: bionic
+language: generic
+script:
+- mkdir -p ~/ros2_latest_ros_launch_sandbox_ws/src
+- cd ~/ros2_latest_ros_launch_sandbox_ws
+- curl https://raw.githubusercontent.com/ros2/ros2/dashing/ros2.repos | vcs import src/
+- curl https://raw.githubusercontent.com/aws-robotics/launch-ros-sandbox/master/launch_ros_sandbox.repos | vcs import src/
+# RTI_NC_LICENSE_ACCEPTED avoids the interactive prompt asking to accept the
+# RTI Connext license.
+# For "latest" builds, rosdep often misses some keys, adding "|| true", to
+# ignore those failures, as it is often non-critical.
+- RTI_NC_LICENSE_ACCEPTED=yes rosdep install -r --from-paths src --ignore-src --rosdistro eloquent -y || true
+- colcon build --event-handlers console_cohesion+ --packages-up-to launch_ros_sandbox --symlink-install
+- colcon test --event-handlers console_cohesion+ --packages-select launch_ros_sandbox --return-code-on-test-failure
+sudo: true


### PR DESCRIPTION
*Description of changes:*

Enable a Travis build to be used on master, compiling ROS 2
from source every single time, using the latest commits of all
ROS 2 repositories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.