### PR TITLE
Fix linting errors and Python types

### DIFF
--- a/launch_ros_sandbox/descriptions/docker_policy.py
+++ b/launch_ros_sandbox/descriptions/docker_policy.py
@@ -19,8 +19,7 @@ Using DockerPolicy, users can load one or more nodes into a particular Docker co
 DockerPolicy requires that Docker 18+ and docker-py 4.0+ is installed.
 
 Example:
---------
-
+-------
 .. code-block:: python
 
     ld = launch.LaunchDescription()

--- a/test/config/mypy.ini
+++ b/test/config/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/test/test_mypy.py
+++ b/test/test_mypy.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 import pytest
 
 
@@ -22,6 +24,9 @@ def test_mypy():
     # of the file. Until then, we still use it internally as developers.
     try:
         from ament_mypy.main import main
-        assert main(argv=[]) == 0, 'Found errors'
+        config_path = Path(__file__).parent / 'config' / 'mypy.ini'
+        print(config_path.resolve())
+        rc = main(argv=['launch_ros_sandbox', '--config', str(config_path.resolve())])
+        assert rc == 0, 'Found code style errors / warnings'
     except ImportError:
         pass


### PR DESCRIPTION
*Description of changes:*

Applying this change fixes the tests:

```
colcon test --event-handlers console_direct+ --packages-select launch_ros_sandbox
Starting >>> launch_ros_sandbox
running pytest
running egg_info
writing /home/ANT.AMAZON.COM/tmoulard/ros2_ws/build/launch_ros_sandbox/launch_ros_sandbox.egg-info/PKG-INFO
writing dependency_links to /home/ANT.AMAZON.COM/tmoulard/ros2_ws/build/launch_ros_sandbox/launch_ros_sandbox.egg-info/dependency_links.txt
writing requirements to /home/ANT.AMAZON.COM/tmoulard/ros2_ws/build/launch_ros_sandbox/launch_ros_sandbox.egg-info/requires.txt
writing top-level names to /home/ANT.AMAZON.COM/tmoulard/ros2_ws/build/launch_ros_sandbox/launch_ros_sandbox.egg-info/top_level.txt
reading manifest file '/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build/launch_ros_sandbox/launch_ros_sandbox.egg-info/SOURCES.txt'
writing manifest file '/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build/launch_ros_sandbox/launch_ros_sandbox.egg-info/SOURCES.txt'
running build_ext
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-5.2.0, py-1.8.0, pluggy-0.13.0 -- /usr/bin/python3
cachedir: ros2_ws/build/launch_ros_sandbox/.pytest_cache
rootdir: /home/ANT.AMAZON.COM/tmoulard, inifile: setup.cfg
plugins: ament-copyright-0.8.0, ament-pep257-0.8.0, ament-flake8-0.8.0, ament-lint-0.8.0, launch-testing-ros-0.9.1, launch-testing-0.9.1, ament-xmllint-0.8.0, ament-mypy-0.8.0, repeat-0.8.0, rerunfailures-7.0, cov-2.8.0
collecting ... 
collected 21 items                                                             

test/test_copyright.py::test_copyright PASSED                            [  4%]
test/test_flake8.py::test_flake8 PASSED                                  [  9%]
test/test_mypy.py::test_mypy PASSED                                      [ 14%]
test/test_pep257.py::test_pep257 PASSED                                  [ 19%]
test/launch_ros_sandbox/actions/test_sandboxed_node_container.py::TestSandboxedNodeContainer::test_launch_docker_policy PASSED [ 23%]
test/launch_ros_sandbox/actions/test_sandboxed_node_container.py::TestSandboxedNodeContainer::test_launch_empty_nodes PASSED [ 28%]
test/launch_ros_sandbox/actions/test_sandboxed_node_container.py::TestSandboxedNodeContainer::test_launch_nodes PASSED [ 33%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_empty_run_args_set_correctly PASSED [ 38%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_entrypoint_assign_default_repo PASSED [ 42%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_entrypoint_assign_default_repo_default_tag PASSED [ 47%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_entrypoint_assign_default_tag PASSED [ 52%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_entrypoint_default_not_osrf_repo PASSED [ 57%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_entrypoint_default_osrf_repo PASSED [ 61%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_image_name_properly_set_if_tag_and_repository_are_defined PASSED [ 66%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_repository_and_tag_defaults_to_osrf_ros_dashing_desktop PASSED [ 71%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_repository_defaults_to_osrf_if_tag_is_defined PASSED [ 76%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_run_args_set_correctly PASSED [ 80%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_tag_defaults_to_dashing_desktop_if_repository_is_manually_set PASSED [ 85%]
test/launch_ros_sandbox/descriptions/test_docker_policy.py::TestDockerPolicy::test_tag_defaults_to_latest_if_repository_is_defined PASSED [ 90%]
test/launch_ros_sandbox/descriptions/test_user.py::TestUser::test_get_user_from_username PASSED [ 95%]
Coverage.py warning: Module b9_ros_github_tools was never imported. (module-not-imported)
Coverage.py warning: No data was collected. (no-data-collected)
test/launch_ros_sandbox/descriptions/test_user_policy.py::TestUserPolicy::test_defaults_to_current_user PASSED [100%]WARNING: Failed to generate report: No data to report.

/home/ANT.AMAZON.COM/tmoulard/.local/lib/python3.6/site-packages/pytest_cov/plugin.py:254: PytestWarning: Failed to generate report: No data to report.

  self.cov_controller.finish()


- generated xml file: /home/ANT.AMAZON.COM/tmoulard/ros2_ws/build/launch_ros_sandbox/pytest.xml -

----------- coverage: platform linux, python 3.6.8-final-0 -----------
Name    Stmts   Miss  Cover   Missing
-------------------------------------

============================== 21 passed in 2.41s ==============================
--- stderr: launch_ros_sandbox
Coverage.py warning: Module b9_ros_github_tools was never imported. (module-not-imported)
Coverage.py warning: No data was collected. (no-data-collected)
/home/ANT.AMAZON.COM/tmoulard/.local/lib/python3.6/site-packages/pytest_cov/plugin.py:254: PytestWarning: Failed to generate report: No data to report.

  self.cov_controller.finish()
---
Finished <<< launch_ros_sandbox [4.44s]

Summary: 1 package finished [5.62s]
  1 package had stderr output: launch_ros_sandbox
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.