### PR TITLE
Fix flake8 issue

### DIFF
--- a/launch_ros_sandbox/actions/load_docker_nodes.py
+++ b/launch_ros_sandbox/actions/load_docker_nodes.py
@@ -20,7 +20,7 @@ LoadDockerNodes is an Action that controls the lifecycle of a sandboxed environm
 as a Docker container. This Action is not exported and should only be used internally.
 """
 
-from asyncio import CancelledError, Future, Task
+import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import shlex
 from threading import Lock
@@ -69,8 +69,8 @@ class LoadDockerNodes(Action):
         super().__init__(**kwargs)
         self._policy = policy
         self._node_descriptions = node_descriptions
-        self._completed_future = None  # type: Optional[Future]
-        self._started_task = None  # type: Optional[Task]
+        self._completed_future = None  # type: Optional[asyncio.Future]
+        self._started_task = None  # type: Optional[asyncio.Task]
         self._container = None  # type: Optional[docker.models.containers.Container]
         self._shutdown_lock = Lock()
         self._docker_client = docker.from_env()
@@ -213,7 +213,7 @@ class LoadDockerNodes(Action):
 
         self._load_nodes_in_docker(context)
 
-    def get_asyncio_future(self) -> Optional[Future]:
+    def get_asyncio_future(self) -> Optional[asyncio.Future]:
         """Return the asyncio Future that represents the lifecycle of the Docker container."""
         return self._completed_future
 
@@ -259,7 +259,7 @@ class LoadDockerNodes(Action):
             if self._started_task is not None:
                 try:
                     self._started_task.cancel()
-                except CancelledError:
+                except asyncio.CancelledError:
                     self._started_task = None
 
             if self._completed_future is not None:


### PR DESCRIPTION
Build is currently failing because I rephrased some typing
annotations as comments, which flake8 is not parsing.
As a result, the build is failing because flake8 is complaining
that some types are not used. To fix this issue, this PR
is importing modules instead of types directly.

```
=================================== FAILURES ===================================
[31m[1m_________________________________ test_flake8 __________________________________[0m
[1m[31mtest/test_flake8.py[0m:23: in test_flake8
[1m    assert rc == 0, 'Found errors'[0m
[1m[31mE   AssertionError: Found errors[0m
[1m[31mE   assert 1 == 0[0m
----------------------------- Captured stdout call -----------------------------

./launch_ros_sandbox/actions/load_docker_nodes.py:23:1: F401 'asyncio.Task' imported but unused
from asyncio import CancelledError, Future, Task
^

1     F401 'asyncio.Task' imported but unused

32 files checked
1 errors

'F'-type errors: 1
```

Travis log with the current failure:
https://api.travis-ci.org/v3/job/594750108/log.txt



*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.