### PR TITLE
Only run Travis on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ addons:
 before_script:
 - sudo rosdep init
 - rosdep update
+branches:
+  only:
+  - master
 cache: apt
 dist: bionic
 language: generic


### PR DESCRIPTION
As Travis runs on PRs automatically, each PR is running each job
twice (one for the branch, one for the PR) which is slowing us down.
We also do not need CI on unstable branches.
Developers can still kick-off builds on custom branches as needed using the Travis interface.



*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.